### PR TITLE
updates to nneo_wrangle

### DIFF
--- a/R/nneo_wrangle.R
+++ b/R/nneo_wrangle.R
@@ -49,8 +49,8 @@
 #' nneo_wrangle(site_code="BART", time_start="2016-06-20",
 #' time_end="2016-09-21", data_var="radiation")
 #' #download 1-minute, dust data from NEON's Sterling (STER) site for 2017-03-04
-#' nneo_wrangle(site_code="STER",time_start="2017-03-04",data_var="dust",
-#' time_agr=60)
+#' nneo_wrangle(site_code="STER",time_start="2017-03-04",
+#' data_var="air temperature",time_agr=30)
 #' }
 
 #' @seealso Currently none

--- a/man/nneo_wrangle.Rd
+++ b/man/nneo_wrangle.Rd
@@ -53,8 +53,8 @@ a custom time period, merged per measurement level and/or variable
 nneo_wrangle(site_code="BART", time_start="2016-06-20",
 time_end="2016-09-21", data_var="radiation")
 #download 1-minute, dust data from NEON's Sterling (STER) site for 2017-03-04
-nneo_wrangle(site_code="STER",time_start="2017-03-04",data_var="dust",
-time_agr=60)
+nneo_wrangle(site_code="STER",time_start="2017-03-04",
+data_var="air temperature",time_agr=30)
 }
 }
 \references{


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
@sckott Fixed the error in the example
## Description
<!--- Describe your changes in detail -->
@sckott noticed an error arising from the second example of the nneo_wrangle function.  The issue is most likely arising due to the fact that we (NEON) are reprocessing some of our data products and the data product called in the example was not present for the selected time.  I changed the data product from "dust" to "air temperature" and the temporal aggregation from "60" to "30."
## Related Issue
<!--- if this closes an issue make sure include e.g., "fix #4"
or similar - or if just relates to an issue make sure to mention
it like "#4" -->
fix #8 
## Example
<!--- if introducing a new feature or changing behavior of existing
methods/functions, include an example if possible to do in brief form -->

<!--- Did you remember to include tests? Unless you're just changing
grammar, please include new tests for your change -->
test-nneo_wragle.R is still a relevant test.