### PR TITLE
Nneo wrangle fix

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,8 @@ Imports:
     jsonlite (>= 1.1),
     tibble (>= 1.2),
     data.table,
-    fauxpas
+    fauxpas,
+    stringr
 Suggests:
     roxygen2 (>= 6.0.1),
     testthat

--- a/R/nneo_wrangle.R
+++ b/R/nneo_wrangle.R
@@ -184,7 +184,7 @@ nneo_wrangle<-function(site_code="CPER",time_start="2017-06-20",time_end=NULL,
                             as.Date(substr(data_merge$startDateTime,0,10))))
     data_filtered<-data_merge[date_filt_start:date_filt_end,]
     #remove columns with all NAs:
-    data_final<-data_filtered[, !apply(is.na(data_filtered), 2, all)]
+    data_final<-tibble::as_tibble(data_filtered[, !apply(is.na(data_filtered), 2, all)])
     #convert to Tibble format and output:
     return(data_final)
 }

--- a/man/nneo_wrangle.Rd
+++ b/man/nneo_wrangle.Rd
@@ -4,8 +4,8 @@
 \alias{nneo_wrangle}
 \title{Download and wrangle NEON's sensor-based data products}
 \usage{
-nneo_wrangle(site_code = "BART", time_start = "2016-06-20",
-  time_end = NULL, data_var = "active radiation", time_agr = 30,
+nneo_wrangle(site_code = "CPER", time_start = "2017-06-20",
+  time_end = NULL, data_var = "temperature", time_agr = 30,
   package = "basic", ...)
 }
 \arguments{
@@ -55,9 +55,9 @@ a custom time period, merged per measurement level and/or variable
 #download 30-minute, radiation data from NEON's Bartlett site for Summer 2016
 nneo_wrangle(site_code="BART", time_start="2016-06-20",
   time_end="2016-09-21", data_var="radiation")
-#download 1-minute, dust data from NEON's Sterling (STER) site for 2017-03-04
+#download 1-minute, temperature data from NEON's Sterling (STER) site for 2017-03-04
 nneo_wrangle(site_code="STER",time_start="2017-03-04",
-  data_var="air temperature",time_agr=30)
+  data_var="temperature",time_agr=30)
 }
 }
 \references{

--- a/man/nneo_wrangle.Rd
+++ b/man/nneo_wrangle.Rd
@@ -55,7 +55,7 @@ a custom time period, merged per measurement level and/or variable
 #download 30-minute, radiation data from NEON's Bartlett site for Summer 2016
 nneo_wrangle(site_code="BART", time_start="2016-06-20",
   time_end="2016-09-21", data_var="radiation")
-#download 1-minute, temperature data from NEON's Sterling (STER) site for 2017-03-04
+#download 30-minute, temperature data from NEON's Sterling (STER) site for 2017-03-04
 nneo_wrangle(site_code="STER",time_start="2017-03-04",
   data_var="temperature",time_agr=30)
 }

--- a/tests/testthat/test-nneo_wrangle.R
+++ b/tests/testthat/test-nneo_wrangle.R
@@ -3,12 +3,12 @@ context("nneo_wrangle")
 test_that("nneo_data works as expected", {
   skip_on_cran()
 
-  aa <- nneo_wrangle(site_code="BART", time_start="2016-06-20",
-                     time_end="2016-09-21", data_var="radiation")
+  aa <- nneo_wrangle(site_code="STER",time_start="2017-03-04",
+                     data_var="temperature",time_agr=30)
 
   expect_is(aa, 'tbl_df')
   # expect_is(aa$difRadMean.000.060, 'numeric')
-  expect_is(aa$difRadMean, 'numeric')
+  expect_is(aa$tempTripleMean.000.040, 'numeric')
   expect_is(aa$startDateTime, 'character')
 
 })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Updates to nneo_wrangle function.  Sensor-based measurement streams have more than 1 replicate measurement were being overwritten and the merge was adding extra rows to the tibble rather than merging by time stamp.  Also, there was an issue with the time filtering at the end.  This has been fixed 


## Related Issue
<!--- if this closes an issue make sure include e.g., "fix #4"
or similar - or if just relates to an issue make sure to mention
it like "#4" -->
@sckott, These fixes should mitigate the issues in #10 for nneo_wrangle.

## Example
<!--- if introducing a new feature or changing behavior of existing
methods/functions, include an example if possible to do in brief form -->
#the following has been added to the testthat script and works as planned.
nneo::nneo_wrangle(site_code="STER",time_start="2017-03-04", data_var="temperature",time_agr=30)

<!--- Did you remember to include tests? Unless you're just changing
grammar, please include new tests for your change -->
